### PR TITLE
arm64 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 ---
 name: Build operator container image
-on: [push]
-  # push:
-  #   tags:
-  #     - "*" # Only runs on pushes with a tag
+on:
+  push:
+    tags:
+      - "*" # Only runs on pushes with a tag
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+---
+name: Build operator container image
+on: [push]
+  # push:
+  #   tags:
+  #     - "*" # Only runs on pushes with a tag
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'arm64,arm'
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Docker Login
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Docker Metadata action
+      uses: docker/metadata-action@v5.0.0
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v5.0.0
+      with:
+        push: true
+        # github.ref_name should set the tag to the pushed tag
+        tags: ghcr.io/${{ github.repository_owner }}/kubernetes-sidecar-terminator:${{ github.ref_name }},ghcr.io/${{ github.repository_owner }}/kubernetes-sidecar-terminator:latest
+
+# Reference: https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
       with:
-        platforms: 'arm64,arm'
+        platforms: 'arm64'
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Docker Login

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       uses: docker/build-push-action@v5.0.0
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         # github.ref_name should set the tag to the pushed tag
         tags: ghcr.io/${{ github.repository_owner }}/kubernetes-sidecar-terminator:${{ github.ref_name }},ghcr.io/${{ github.repository_owner }}/kubernetes-sidecar-terminator:latest
 


### PR DESCRIPTION
This adds a Github Action which builds the image with the usual amd64 and with arm64 and pushes it to ghcr. 

I configured it to only run on tagged pushes so the image doesn't have to get rebuilt by every small commit. This could be changed if undesired.